### PR TITLE
removed $ from the snippets so the copy button works again

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,19 +5,19 @@ EDICTOR is a web-based tool for computer-assisted language comparison. As of Ver
 In order to get started with the local application, you should make sure to have a recent Python installation (3.8 or higher) along with the PIP package manager. It is recommended to install the package from a virtual environment. Installing EDICTOR can then be done via the commandline by simply typing:
 
 ```shell
-$ pip install edictor3
+pip install edictor3
 ```
 
 This will install EDICTOR on your computer and offer the command `edictor3` on your commandline that you can use to run the application locally.
 
 ```shell
-$ edictor3
+edictor3
 ```
 
 Running the application will try to automatically open the webbrowser at the default address `http://localhost:9999`. If that causes errors, you can select another port.
 
 ```shell
-$ edictor3 --port=9876
+edictor3 --port=9876
 ```
 
 The landing page will provide further information on files and datasets that you can open and test.


### PR DESCRIPTION
Small usability fix. Three lines of shell command in the readme had a leading `$` which would be copied with the copy button, preventing the command from working at first. This change removes them to make it consistent with the other lines of code and improve user-friendliness.