### PR TITLE
add variable for script url

### DIFF
--- a/src/edictor/wordlist.py
+++ b/src/edictor/wordlist.py
@@ -23,11 +23,12 @@ def fetch_wordlist(
         to_lingpy=None,
         transform=None,
         base_url="http://lingulist.de/edictor",
+        script_url="/triples/get_data.py"
 ):
     """
     Download wordlist from an EDICTOR server application.
     """
-    url = base_url + "/triples/get_data.py?file=" + dataset
+    url = base_url + script_url + "?file=" + dataset
     if not remote_dbase:
         url += "&remote_dbase=" + dataset + ".sqlite3"
     else:

--- a/tests/test_wordlist.py
+++ b/tests/test_wordlist.py
@@ -19,6 +19,13 @@ def test_fetch_wordlist():
     data = fetch_wordlist("sumerian", to_lingpy=True)
     assert data.width == 2
 
+    data = fetch_wordlist(
+        "migliazzayanomamic",
+        base_url='http://lingulist.de/pth/',
+        script_url='get_data.py'
+        )
+    assert data[:2] == "ID"
+
 
 def test_get_wordlist():
 


### PR DESCRIPTION
@LinguList This PR adds a variable `script_url` with `/triples/get_data.py` set as default. The code was tested for the 'migliazzayanomamic' dataset.